### PR TITLE
Fix: move '_run()' in TimelockProposal

### DIFF
--- a/proposals/proposalTypes/TimelockProposal.sol
+++ b/proposals/proposalTypes/TimelockProposal.sol
@@ -111,4 +111,9 @@ abstract contract TimelockProposal is Proposal {
         console.log("\n\n------------------ Execute Calldata ------------------");
         console.logBytes(getExecuteCalldata());
     }
+
+    function _run() internal virtual override {
+        if (actions.length == 0) return;
+        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
+    }
 }

--- a/proposals/zips/zip003.sol
+++ b/proposals/zips/zip003.sol
@@ -331,10 +331,4 @@ contract zip003 is TimelockProposal {
         /// grant game consumer notary protocol role
         _core.grantRole(Roles.GAME_CONSUMER_NOTARY_PROTOCOL_ROLE, addresses.getAddress("AUTOGRAPH_SERVICE_KMS_WALLET"));
     }
-
-    function _run() internal override {
-        super._run();
-
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
 }

--- a/proposals/zips/zip004.sol
+++ b/proposals/zips/zip004.sol
@@ -251,10 +251,6 @@ contract zip004 is TimelockProposal {
         seasonOne.initalizeSeasonDistribution(tokenIdRewardAmounts);
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         /// Verfiy Placeable
         for (uint256 i = 0; i < placeableTokenIDMaxSupplySettings.length; i++) {

--- a/proposals/zips/zip005.sol
+++ b/proposals/zips/zip005.sol
@@ -150,10 +150,6 @@ contract zip005 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         /// Verfiy Placeable
         for (uint256 i = 0; i < placeableTokenIDMaxSupplySettings.length; i++) {

--- a/proposals/zips/zip006.sol
+++ b/proposals/zips/zip006.sol
@@ -69,10 +69,6 @@ contract zip006 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         /// Verfiy Wearable
         for (uint256 i = 0; i < wearableTokenIDMaxSupplySettings.length; i++) {

--- a/proposals/zips/zip007.sol
+++ b/proposals/zips/zip007.sol
@@ -69,10 +69,6 @@ contract zip007 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         /// Verfiy Wearable
         for (uint256 i = 0; i < wearableTokenIDMaxSupplySettings.length; i++) {

--- a/proposals/zips/zip008.sol
+++ b/proposals/zips/zip008.sol
@@ -67,10 +67,6 @@ contract zip008 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zip009.sol
+++ b/proposals/zips/zip009.sol
@@ -67,10 +67,6 @@ contract zip009 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zip010.sol
+++ b/proposals/zips/zip010.sol
@@ -66,10 +66,6 @@ contract zip010 is TimelockProposal {
         placeables.setSupplyCap(placeableTokenIDMaxSupplySettings[0].tokenId, placeableTokenIDMaxSupplySettings[0].maxSupply);
     }
 
-    function _run() internal override {
-        _simulateActions(addresses.getAddress("ADMIN_MULTISIG"), addresses.getAddress("ADMIN_MULTISIG"));
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable placeable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_PLACEABLES")

--- a/proposals/zips/zip011.sol
+++ b/proposals/zips/zip011.sol
@@ -76,13 +76,6 @@ contract zip011 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(
-            addresses.getAddress("ADMIN_MULTISIG"),
-            addresses.getAddress("ADMIN_MULTISIG")
-        );
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zip012.sol
+++ b/proposals/zips/zip012.sol
@@ -66,13 +66,6 @@ contract zip012 is TimelockProposal {
         wearables.setSupplyCap(wearableTokenIDMaxSupplySettings[0].tokenId, wearableTokenIDMaxSupplySettings[0].maxSupply);
     }
 
-    function _run() internal override {
-        _simulateActions(
-            addresses.getAddress("ADMIN_MULTISIG"),
-            addresses.getAddress("ADMIN_MULTISIG")
-        );
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zip013.sol
+++ b/proposals/zips/zip013.sol
@@ -78,13 +78,6 @@ contract zip013 is TimelockProposal {
         }
     }
 
-    function _run() internal override {
-        _simulateActions(
-            addresses.getAddress("ADMIN_MULTISIG"),
-            addresses.getAddress("ADMIN_MULTISIG")
-        );
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zip014.sol
+++ b/proposals/zips/zip014.sol
@@ -66,13 +66,6 @@ contract zip014 is TimelockProposal {
         wearables.setSupplyCap(wearableTokenIDMaxSupplySettings[0].tokenId, wearableTokenIDMaxSupplySettings[0].maxSupply);
     }
 
-    function _run() internal override {
-        _simulateActions(
-            addresses.getAddress("ADMIN_MULTISIG"),
-            addresses.getAddress("ADMIN_MULTISIG")
-        );
-    }
-
     function _validate() internal override {
         ERC1155MaxSupplyMintable wearable = ERC1155MaxSupplyMintable(
             addresses.getAddress("ERC1155_MAX_SUPPLY_MINTABLE_WEARABLES")

--- a/proposals/zips/zipTemplate.sol
+++ b/proposals/zips/zipTemplate.sol
@@ -1,38 +1,33 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.18;
 
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import {Addresses} from "@proposals/Addresses.sol";
-import {Proposal} from "@proposals/proposalTypes/Proposal.sol";
 import {TimelockProposal} from "@proposals/proposalTypes/TimelockProposal.sol";
 
-import {Core} from "@protocol/core/Core.sol";
-import {Roles} from "@protocol/core/Roles.sol";
-import {Token, MAX_SUPPLY} from "@protocol/token/Token.sol";
-import {ERC20HoldingDeposit} from "@protocol/finance/ERC20HoldingDeposit.sol";
+contract zipTemplate is TimelockProposal {
+    constructor() Proposal("ADMIN_TIMELOCK_CONTROLLER") {}
 
-contract zipTemplate is Proposal, TimelockProposal {
-    string public name = "ZIPTEMPLATE";
-    string public description = "Template proposal";
+    // Returns the name of the proposal.
+    function name() public pure override returns (string memory) {
+        return "ZIPTEMPLATE";
+    }
 
-    function _beforeDeploy(Addresses, address deployer) internal override {}
+    // Provides a brief description of the proposal.
+    function description() public pure override returns (string memory) {
+        return "Template proposal";
+    }
 
-    function _deploy(Addresses addresses, address) internal override {}
+    function _beforeDeploy() internal override {}
 
-    function _afterDeploy(Addresses addresses, address) internal override {}
+    function _deploy() internal override {}
 
-    function _afterDeployOnChain(Addresses, address deployer) internal virtual override {}
+    function _afterDeploy() internal override {}
 
-    function _validate(Addresses addresses, address) internal override {}
+    function _build() internal override {}
 
-    function _validateOnChain(Addresses, address deployer) internal virtual override {}
+    function _run() internal override {}
 
-    function _validateForTestingOnly(Addresses, address deployer) internal virtual override {}
+    function _teardown() internal override {}
 
-    function _teardown(Addresses addresses, address deployer) internal override {}
-
-    function _build(Addresses addresses, address deployer) internal override {}
-
-    function _run(Addresses addresses, address deployer) internal override {}
+    function _validate() internal override {}
 }


### PR DESCRIPTION
## Description
1. Move `_run()` from zips to `TimelockProposal`.
2. Update `ZipTemplate`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

-   [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [ ] ~added `!` to the type prefix if API or client breaking change~
-   [ ] ~provided a link to the relevant issue or specification~
-   [x] included the necessary unit and integration tests
-   [x] code is adequately commented
-   [ ] ~updated the relevant documentation or specification~
-   [x] reviewed "Files changed" and left comments if necessary
-   [x] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

-   [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [ ] confirmed `!` in the type prefix if API or client breaking change
-   [x] confirmed all author checklist items have been addressed
-   [x] reviewed service design and naming
-   [x] reviewed documentation is accurate
-   [x] reviewed tests and test coverage
-   [x] manually tested (if applicable)
