### PR TITLE
fix: after deploy cleanup

### DIFF
--- a/proposals/Addresses/localnet.json
+++ b/proposals/Addresses/localnet.json
@@ -64,11 +64,5 @@
         "chainid": 31337,
         "addr": "0x0000000000000000000000000000000000000108",
         "isContract": false
-    },
-    {
-        "name": "AFTER_DEPLOY_CALLER",
-        "chainid": 31337,
-        "addr": "0x0000000000000000000000000000000000000108",
-        "isContract": false
     }
 ]

--- a/proposals/Addresses/mainnet.json
+++ b/proposals/Addresses/mainnet.json
@@ -142,11 +142,5 @@
         "addr": "0x6FAEb7C2A9c2BF2d4Da601227A023eCC8FbAC0e6",
         "chainId": 42161,
         "isContract": false
-    },
-    {
-        "name": "AFTER_DEPLOY_CALLER",
-        "addr": "0x5dE36e1b22520975021950c0ca190027A6f73aAa",
-        "chainId": 42161,
-        "isContract": true
     }
 ]

--- a/proposals/proposalTypes/Proposal.sol
+++ b/proposals/proposalTypes/Proposal.sol
@@ -60,10 +60,6 @@ abstract contract Proposal is Test, Script, IProposal {
         vm.startBroadcast(deployer);
         _beforeDeploy();
         _deploy();
-        vm.stopBroadcast();
-
-        address afterDeployCaller = addresses.getAddress("AFTER_DEPLOY_CALLER");
-        vm.startBroadcast(afterDeployCaller);
         _afterDeploy();
         vm.stopBroadcast();
 

--- a/proposals/zips/zip002.sol
+++ b/proposals/zips/zip002.sol
@@ -13,6 +13,7 @@ import {Roles} from "@protocol/core/Roles.sol";
 import {Token, MAX_SUPPLY} from "@protocol/token/Token.sol";
 import {ERC20HoldingDeposit} from "@protocol/finance/ERC20HoldingDeposit.sol";
 import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+import {Constants} from '@proposals/utils/Constants.sol';
 
 contract zip002 is TimelockProposal {
     TimelockController private _adminTimelock;
@@ -54,7 +55,9 @@ contract zip002 is TimelockProposal {
     function _afterDeploy() internal override {
         /// For the sake of testing, give the ADMIN role to the ADMIN_TIMELOCK_CONTROLLER.
         /// This is not possible onchain as the deployer is not an Admin
-        _core.grantRole(Roles.ADMIN, addresses.getAddress("ADMIN_TIMELOCK_CONTROLLER"));
+        if (block.chainid != Constants.ARBITRUM_MAINNET) {
+            _core.grantRole(Roles.ADMIN, addresses.getAddress("ADMIN_TIMELOCK_CONTROLLER"));
+        }
 
         /// The ADMIN_MULTISIG now needs to give the ADMIN role to the ADMIN_TIMELOCK_CONTROLLER
         console.log("Please give Roles.Admin to the ADMIN_TIMELOCK_CONTROLLER from the ADMIN_MULTISIG");

--- a/proposals/zips/zipTest.sol
+++ b/proposals/zips/zipTest.sol
@@ -153,41 +153,6 @@ contract zipTest is TimelockProposal {
         }
     }
 
-    function _afterDeploy() internal override {
-        /// ADMIN role
-        _core.grantRole(Roles.ADMIN, addresses.getAddress("ADMIN_TIMELOCK_CONTROLLER"));
-
-        /// LOCKER role
-        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_CONSUMABLES"));
-        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_PLACEABLES"));
-        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_WEARABLES"));
-
-        /// MINTER role
-        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_CONSUMABLES"));
-        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_PLACEABLES"));
-        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_WEARABLES"));
-
-        /// TOKEN_GOVERNOR role
-        _core.grantRole(Roles.GOVERNOR_DAO_PROTOCOL_ROLE, addresses.getAddress("GOVERNOR_DAO"));
-
-        /// GUARDIAN role
-        _core.grantRole(Roles.GUARDIAN, addresses.getAddress("GUARDIAN_MULTISIG"));
-
-        /// FINANCIAL_CONTROLLER role
-        _core.grantRole(Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE, addresses.getAddress("TREASURY_WALLET_MULTISIG"));
-        _core.grantRole(
-            Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE,
-            addresses.getAddress("WETH_TREASURY_HOLDING_DEPOSIT")
-        );
-        _core.grantRole(
-            Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE,
-            addresses.getAddress("GOVERNOR_DAO_TIMELOCK_CONTROLLER")
-        );
-
-        /// FINANCIAL_GUARDIAN Role
-        _core.grantRole(Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE, addresses.getAddress("FINANCE_GUARDIAN_MULTISIG"));
-    }
-
     function _validate() internal override {
         assertEq(
             address(ERC1155Sale(addresses.getAddress("ERC1155_SALE_CONSUMABLES")).core()),
@@ -285,5 +250,35 @@ contract zipTest is TimelockProposal {
     function _build() internal override {
         /// ADMIN role
         _core.grantRole(Roles.ADMIN, addresses.getAddress("ADMIN_TIMELOCK_CONTROLLER"));
+
+        /// LOCKER role
+        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_CONSUMABLES"));
+        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_PLACEABLES"));
+        _core.grantRole(Roles.LOCKER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_WEARABLES"));
+
+        /// MINTER role
+        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_CONSUMABLES"));
+        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_PLACEABLES"));
+        _core.grantRole(Roles.MINTER_PROTOCOL_ROLE, addresses.getAddress("ERC1155_SALE_WEARABLES"));
+
+        /// TOKEN_GOVERNOR role
+        _core.grantRole(Roles.GOVERNOR_DAO_PROTOCOL_ROLE, addresses.getAddress("GOVERNOR_DAO"));
+
+        /// GUARDIAN role
+        _core.grantRole(Roles.GUARDIAN, addresses.getAddress("GUARDIAN_MULTISIG"));
+
+        /// FINANCIAL_CONTROLLER role
+        _core.grantRole(Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE, addresses.getAddress("TREASURY_WALLET_MULTISIG"));
+        _core.grantRole(
+            Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE,
+            addresses.getAddress("WETH_TREASURY_HOLDING_DEPOSIT")
+        );
+        _core.grantRole(
+            Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE,
+            addresses.getAddress("GOVERNOR_DAO_TIMELOCK_CONTROLLER")
+        );
+
+        /// FINANCIAL_GUARDIAN Role
+        _core.grantRole(Roles.FINANCIAL_CONTROLLER_PROTOCOL_ROLE, addresses.getAddress("FINANCE_GUARDIAN_MULTISIG"));
     }
 }


### PR DESCRIPTION
## Description

There should be a single account that does all the actions before `build`. If there is an action that can only be executed by `ADMIN_MULTISIG` not by `ZTX_DEPLOYER` then it should be the part of the `build`.
To achieve this, this pr updates to a single broadcast before build, removing `AFTER_DEPLOY_CALLER` and move `afterDeploy` actions performed by ADMIN_MULTISIG in zips to `build`.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->


---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

-   [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [ ] ~added `!` to the type prefix if API or client breaking change~
-   [ ] ~provided a link to the relevant issue or specification~
-   [x] included the necessary unit and integration tests
-   [x] code is adequately commented
-   [ ] ~updated the relevant documentation or specification~
-   [x] reviewed "Files changed" and left comments if necessary
-   [x] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

-   [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [ ] confirmed `!` in the type prefix if API or client breaking change
-   [ ] confirmed all author checklist items have been addressed
-   [ ] reviewed service design and naming
-   [ ] reviewed documentation is accurate
-   [ ] reviewed tests and test coverage
-   [ ] manually tested (if applicable)
