### PR TITLE
feat: add non-transferable token support to ERC1155MaxSupplyMintable & burns no longer reduce total supply of tokens

### DIFF
--- a/doc/contracts/nfts/ERC1155MaxSupplyMintable.md
+++ b/doc/contracts/nfts/ERC1155MaxSupplyMintable.md
@@ -1,7 +1,7 @@
 # ERC1155MaxSupplyMintable.sol
 
 ## Introduction
-An extension of the standard ERC1155 multi-token interface. Designed to cater to both fungible and non-fungible tokens, it introduces a mechanism to manage the maximum supply of each individual token.
+An extension of the standard ERC1155 multi-token interface. Designed to cater to both fungible and non-fungible tokens, it introduces a mechanism to manage the maximum supply of each individual token and supports non-transferable (soulbound-like) tokens.
 
 ### Overview
 The diagrams below provide a visual representation of how `ERC1155MaxSupplyMintable.sol` interacts with its various features and dependencies. It primarily shows the flow of actions a user can initiate and how the contract interacts with other referenced contracts and utilities.
@@ -9,13 +9,12 @@ The diagrams below provide a visual representation of how `ERC1155MaxSupplyMinta
 #### Top-down
 ```mermaid
 graph TD
-    ERC1155MaxSupplyMintable --> ERC1155Supply
     ERC1155MaxSupplyMintable --> ERC1155Burnable
     ERC1155MaxSupplyMintable --> CoreRef
     ERC1155MaxSupplyMintable --> Roles
     ERC1155MaxSupplyMintable --> Strings
-    
-    ERC1155Supply --> ERC1155
+
+    ERC1155Burnable --> ERC1155
 ```
 
 #### Sequence
@@ -30,6 +29,21 @@ sequenceDiagram
     alt ADMIN role
         ERC1155MaxSupplyMintable->>ERC1155MaxSupplyMintable: _setSupplyCap(...)
         ERC1155MaxSupplyMintable-->>ERC1155MaxSupplyMintable: Emit SupplyCapUpdated event
+    else
+        ERC1155MaxSupplyMintable-->>-User: Revert
+    end
+
+    User->>+ERC1155MaxSupplyMintable: setSupplyCapAndNonTransferable(...)
+    alt ADMIN role
+        ERC1155MaxSupplyMintable->>ERC1155MaxSupplyMintable: _setSupplyCap(...)
+        ERC1155MaxSupplyMintable->>ERC1155MaxSupplyMintable: _setNonTransferable(...)
+    else
+        ERC1155MaxSupplyMintable-->>-User: Revert
+    end
+
+    User->>+ERC1155MaxSupplyMintable: setNonTransferable(...)
+    alt ADMIN role and token initialized
+        ERC1155MaxSupplyMintable->>ERC1155MaxSupplyMintable: _setNonTransferable(...)
     else
         ERC1155MaxSupplyMintable-->>-User: Revert
     end
@@ -81,18 +95,21 @@ sequenceDiagram
 ## Base Contracts
 ### OpenZeppelin
 - [ERC1155](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/ERC1155.sol): A standardized interface for multi-token contracts. Each token in ERC1155 can represent any value (fungible, non-fungible, or a mixture).
-- [ERC1155Supply](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/extensions/ERC1155Supply.sol): Extension of the ERC1155 standard that adds tracking of the total supply for each token.
 - [ERC1155Burnable](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/extensions/ERC1155Burnable.sol): Extension of the ERC1155 standard that adds a burn function, allowing holders of tokens to destroy them.
 ### Protocol Specific
 - [Strings](https://github.com/ZTX-Foundation/tuxedo/blob/develop/src/utils/Strings.sol): A utility library for handling string operations in Solidity.
 - [Roles](https://github.com/ZTX-Foundation/tuxedo/blob/develop/src/core/Roles.sol): Manages different roles for access control.
 - [CoreRef](https://github.com/ZTX-Foundation/tuxedo/blob/develop/src/refs/CoreRef.sol): Provides a reference to the protocol's core contract.
 
+**Note:** This contract implements custom total supply tracking instead of using ERC1155Supply. The custom implementation ensures that burned tokens still count towards the max supply cap, preventing infinite minting through burn/mint cycles.
+
 ## Features
-- Easily track of the total supply of each token ID.
+- Easily track the total supply of each token ID with custom logic that counts burned tokens towards the max supply.
 - Enables token holders to burn (destroy) their tokens.
 - Ability to change the metadata base URI.
 - Setting and updating of supply caps for individual token IDs.
+- Support for non-transferable tokens (soulbound-like) on a per-token basis.
+- Non-transferable tokens can still be minted and burned but cannot be transferred between addresses.
 - Batch minting.
 
 ## Events
@@ -153,6 +170,27 @@ Allows `ADMIN` to set the supply cap for a specific token. The new supply cap mu
 ### `_setSupplyCap()`
 An internal function to set the supply cap for a given token. Emits a `SupplyCapUpdated` event.
 
+### `setSupplyCapAndNonTransferable()`
+Allows `ADMIN` to set both the supply cap and non-transferability status for a specific token in a single transaction. This is useful when initializing a new token. The token must not already have a max supply set if setting to non-transferable.
+
+**Parameters:**
+- `tokenId`: The ID of the token to configure.
+- `maxSupply`: The maximum supply cap for the token.
+- `isNonTransferable`: Whether the token should be non-transferable (true) or transferable (false).
+
+### `setNonTransferable()`
+Allows `ADMIN` to toggle the transferability of a specific token. This can be used to make a token non-transferable (soulbound-like) or to re-enable transfers for a previously non-transferable token.
+
+**Parameters:**
+- `tokenId`: The ID of the token to update.
+- `isNonTransferable`: Whether the token should be non-transferable (true) or transferable (false).
+
+**Requirements:**
+- The token must have a max supply greater than 0 (i.e., the token must be initialized).
+
+### `_setNonTransferable()`
+An internal function to set the non-transferability status for a given token. Validates that the token has been initialized with a max supply before allowing the transferability to be set.
+
 ### `setURI()`
 Allows `ADMIN` to update the URI (metadata) for the token.
 
@@ -163,7 +201,7 @@ Allows `MINTER` to mint tokens for a specific recipient. The number of tokens mi
 Allows `MINTER` to mint a batch of tokens for a specific recipient. The total number of tokens minted across all IDs must not exceed the respective supply caps. Emits a `BatchMinted` event.
 
 ### `getMintAmountLeft()`
-A view function that returns the amount of tokens that can still be minted before reaching the supply cap for a specific token.
+A view function that returns the amount of tokens that can still be minted before reaching the supply cap for a specific token. Note that this takes into account burned tokens, as they permanently count towards the max supply.
 
 ### `name()`
 View function that returns the name of the collection.
@@ -171,8 +209,23 @@ View function that returns the name of the collection.
 ### `symbol()`
 View function that returns the symbol of the collection.
 
+### `exists()`
+A view function that returns whether any tokens with the given ID have been minted (based on total supply).
+
+**Parameters:**
+- `id`: The token ID to check.
+
+**Returns:**
+- `bool`: True if the token has been minted (total supply > 0), false otherwise.
+
 ### `_beforeTokenTransfer()`
-An internal override function to disallow sending tokens to the token contract itself.
+An internal override function that:
+1. Enforces non-transferability rules: Blocks transfers (but not mints or burns) for tokens marked as non-transferable.
+2. Tracks total supply: Only increments total supply on mints, not decrements on burns. This ensures burned tokens permanently count towards the max supply cap.
+
+**Transfer Blocking Logic:**
+- If a token is marked as non-transferable, any attempt to transfer it between addresses will revert with "BaseERC1155NFT: token is non-transferable".
+- Minting (from address(0)) and burning (to address(0)) are always allowed, even for non-transferable tokens.
 
 ### `uri()`
 A view function that generates the URI for a specific token ID, including its string representation.

--- a/src/nfts/ERC1155MaxSupplyMintable.sol
+++ b/src/nfts/ERC1155MaxSupplyMintable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.18;
 
-import {ERC1155, ERC1155Supply} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Supply.sol";
 import {ERC1155Burnable} from "@openzeppelin/contracts/token/ERC1155/extensions/ERC1155Burnable.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 
@@ -10,7 +10,7 @@ import {CoreRef} from "@protocol/refs/CoreRef.sol";
 
 /// Base ERC 1155 NFT with total supply
 /// Inherits CoreRef for roles and access
-contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
+contract ERC1155MaxSupplyMintable is ERC1155Burnable, CoreRef {
     /// @notice contract name
     string private _name;
 
@@ -35,6 +35,12 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
     /// @notice the maximum supply of a given token
     mapping(uint256 tokenId => uint256 tokenMaxSupply) public maxTokenSupply;
 
+    /// @notice the total supply of tokens minted for a given token id, does not decrease on burn
+    mapping(uint256 => uint256) public totalSupply;
+
+    /// @notice mapping to track non-transferable tokens, tokens initially are transferable and require disabling
+    mapping(uint256 tokenId => bool isNonTransferable) public nonTransferableTokens;
+
     /// @notice construct the ERC1155 with total supply and CoreRef
     constructor(
         address _core,
@@ -44,6 +50,21 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
     ) CoreRef(_core) ERC1155(_uri) {
         _name = name_;
         _symbol = symbol_;
+    }
+
+    /// @notice set the supply cap and transferability for a given token, cannot be less than current supply
+    /// @param tokenId the id of the token to update
+    /// @param maxSupply the new max supply of the token
+    /// @param isNonTransferable whether the token should be non-transferable
+    /// callable by admin
+    function setSupplyCapAndTransferable(
+        uint256 tokenId,
+        uint256 maxSupply,
+        bool isNonTransferable
+    ) external onlyRole(Roles.ADMIN) {
+        _setSupplyCap(tokenId, maxSupply);
+
+        nonTransferableTokens[tokenId] = isNonTransferable;
     }
 
     /// @notice set the supply cap for a given token, cannot be less than current supply
@@ -57,7 +78,7 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
     /// @param tokenId the id of the token to update
     /// @param maxSupply the new max supply of the token
     function _setSupplyCap(uint256 tokenId, uint256 maxSupply) internal {
-        require(maxSupply >= totalSupply(tokenId), "BaseERC1155NFT: maxSupply cannot be less than current supply");
+        require(maxSupply >= totalSupply[tokenId], "BaseERC1155NFT: maxSupply cannot be less than current supply");
 
         uint256 oldSupplyCap = maxTokenSupply[tokenId];
         maxTokenSupply[tokenId] = maxSupply;
@@ -86,13 +107,13 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
         uint256 tokenId,
         uint256 amount
     ) external onlyRole(Roles.MINTER_PROTOCOL_ROLE) whenNotPaused globalLock(2) {
-        require(totalSupply(tokenId) + amount <= maxTokenSupply[tokenId], "BaseERC1155NFT: supply exceeded");
+        require(totalSupply[tokenId] + amount <= maxTokenSupply[tokenId], "BaseERC1155NFT: supply exceeded");
 
         /// no bytes passed on mint
         _mint(recipient, tokenId, amount, "");
 
         /// check for SMT solver and echidna
-        assert(totalSupply(tokenId) <= maxTokenSupply[tokenId]);
+        assert(totalSupply[tokenId] <= maxTokenSupply[tokenId]);
 
         emit TokenMinted(recipient, tokenId, amount);
     }
@@ -110,7 +131,7 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
         _mintBatch(recipient, tokenIds, amounts, "");
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            require(totalSupply(tokenIds[i]) <= maxTokenSupply[tokenIds[i]], "BaseERC1155NFT: supply exceeded");
+            require(totalSupply[tokenIds[i]] <= maxTokenSupply[tokenIds[i]], "BaseERC1155NFT: supply exceeded");
         }
 
         emit BatchMinted(recipient, tokenIds, amounts);
@@ -121,7 +142,7 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
     /// @notice returns the amount of tokens left to mint from the max supply
     /// @param tokenId the id of the token to query
     function getMintAmountLeft(uint256 tokenId) public view returns (uint256) {
-        return maxTokenSupply[tokenId] - totalSupply(tokenId);
+        return maxTokenSupply[tokenId] - totalSupply[tokenId];
     }
 
     /// @notice returns the name of the token
@@ -134,17 +155,31 @@ contract ERC1155MaxSupplyMintable is ERC1155Supply, ERC1155Burnable, CoreRef {
         return _symbol;
     }
 
+    /// @notice indicates whether any token exist with a given id, or not
+    /// @param id the id of the token to query
+    function exists(uint256 id) public view virtual returns (bool) {
+        return totalSupply[id] > 0;
+    }
+
     /// ----------- INTERNAL OVERRIDES ------------
 
+    /// @dev override of ERC1155 _beforeTokenTransfer hook to track total supply
+    /// @notice only increases total supply on mints, does not decrease on burns
+    /// this ensures that burned tokens still count towards the max supply cap
     function _beforeTokenTransfer(
-        address operator,
+        address,
         address from,
-        address to,
+        address,
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory
-    ) internal override(ERC1155, ERC1155Supply) {
-        ERC1155Supply._beforeTokenTransfer(operator, from, to, ids, amounts, "");
+    ) internal override {
+        // Only increase the total supply on mints
+        if (from == address(0)) {
+            for (uint256 i = 0; i < ids.length; ++i) {
+                totalSupply[ids[i]] += amounts[i];
+            }
+        }
     }
 
     // Needed for openSea with ERC1155

--- a/src/nfts/ERC1155MaxSupplyMintable.sol
+++ b/src/nfts/ERC1155MaxSupplyMintable.sol
@@ -52,17 +52,36 @@ contract ERC1155MaxSupplyMintable is ERC1155Burnable, CoreRef {
         _symbol = symbol_;
     }
 
-    /// @notice set the supply cap and transferability for a given token, cannot be less than current supply
+    /// @notice set the supply cap and non-transferability for a given token, cannot be less than current supply
     /// @param tokenId the id of the token to update
     /// @param maxSupply the new max supply of the token
     /// @param isNonTransferable whether the token should be non-transferable
     /// callable by admin
-    function setSupplyCapAndTransferable(
+    function setSupplyCapAndNonTransferable(
         uint256 tokenId,
         uint256 maxSupply,
         bool isNonTransferable
     ) external onlyRole(Roles.ADMIN) {
         _setSupplyCap(tokenId, maxSupply);
+        _setNonTransferable(tokenId, isNonTransferable);
+    }
+
+    /// @notice set the non-transferability for a given token
+    /// @param tokenId the id of the token to update
+    /// @param isNonTransferable whether the token should be non-transferable
+    /// callable by admin
+    function setNonTransferable(uint256 tokenId, bool isNonTransferable) external onlyRole(Roles.ADMIN) {
+        _setNonTransferable(tokenId, isNonTransferable);
+    }
+
+    /// @dev internal function to set the non-transferability for a given token
+    /// @param tokenId the id of the token to update
+    /// @param isNonTransferable whether the token should be non-transferable
+    function _setNonTransferable(uint256 tokenId, bool isNonTransferable) internal {
+        require(
+            maxTokenSupply[tokenId] > 0,
+            "BaseERC1155NFT: token must have a max supply greater than 0 to set the transferability"
+        );
 
         nonTransferableTokens[tokenId] = isNonTransferable;
     }

--- a/src/nfts/ERC1155MaxSupplyMintable.sol
+++ b/src/nfts/ERC1155MaxSupplyMintable.sol
@@ -182,17 +182,25 @@ contract ERC1155MaxSupplyMintable is ERC1155Burnable, CoreRef {
 
     /// ----------- INTERNAL OVERRIDES ------------
 
-    /// @dev override of ERC1155 _beforeTokenTransfer hook to track total supply
+    /// @dev override of ERC1155 _beforeTokenTransfer hook to track total supply and enforce non-transferability
     /// @notice only increases total supply on mints, does not decrease on burns
     /// this ensures that burned tokens still count towards the max supply cap
+    /// @notice also blocks transfers of non-transferable tokens (mints and burns are still allowed)
     function _beforeTokenTransfer(
         address,
         address from,
-        address,
+        address to,
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory
     ) internal override {
+        // Block transfers of non-transferable tokens (but allow mints and burns)
+        if (from != address(0) && to != address(0)) {
+            for (uint256 i = 0; i < ids.length; ++i) {
+                require(!nonTransferableTokens[ids[i]], "BaseERC1155NFT: token is non-transferable");
+            }
+        }
+
         // Only increase the total supply on mints
         if (from == address(0)) {
             for (uint256 i = 0; i < ids.length; ++i) {

--- a/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
+++ b/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
@@ -66,6 +66,24 @@ contract UnitTestERC1155MaxSupplyMintable is BaseTest {
         nft.setSupplyCap(tokenId, supplyCap - 1);
     }
 
+    function testSetSupplyCapAndTransferableWithoutRoleFails() public {
+        vm.expectRevert("CoreRef: no role on core");
+        nft.setSupplyCapAndTransferable(tokenId, supplyCap, true);
+    }
+
+    function testSetSupplyCapAndTransferableWithRoleSucceeds() public {
+        uint256 newTokenId = tokenId + 1;
+        uint256 newSupplyCap = 5000;
+        bool isNonTransferable = true;
+
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCapAndTransferable(newTokenId, newSupplyCap, isNonTransferable);
+
+        assertEq(nft.maxTokenSupply(newTokenId), newSupplyCap);
+        assertEq(nft.getMintAmountLeft(newTokenId), newSupplyCap);
+        assertEq(nft.nonTransferableTokens(newTokenId), isNonTransferable);
+    }
+
     function testPauseWithoutRoleFails() public {
         vm.expectRevert("CoreRef: no role on core");
         nft.pause();
@@ -172,21 +190,22 @@ contract UnitTestERC1155MaxSupplyMintable is BaseTest {
         nft.mint(address(this), tokenId, amount);
     }
 
-    function testBurnDecreasesSupply() public {
+    function testBurnUnchangedSupply() public {
         testMintBatchSucceedsMinter();
+        uint256 amount = 100;
 
         nft.burn(address(this), tokenId, nft.balanceOf(address(this), tokenId));
         nft.burn(address(this), tokenId + 1, nft.balanceOf(address(this), tokenId + 1));
 
         assertEq(nft.balanceOf(address(this), tokenId), 0);
         assertEq(nft.balanceOf(address(this), tokenId + 1), 0);
-        assertEq(nft.totalSupply(tokenId), 0);
-        assertEq(nft.totalSupply(tokenId + 1), 0);
-        assertEq(nft.getMintAmountLeft(tokenId), supplyCap);
-        assertEq(nft.getMintAmountLeft(tokenId + 1), supplyCap);
+        assertEq(nft.totalSupply(tokenId), amount);
+        assertEq(nft.totalSupply(tokenId + 1), amount);
+        assertEq(nft.getMintAmountLeft(tokenId), supplyCap - amount);
+        assertEq(nft.getMintAmountLeft(tokenId + 1), supplyCap - amount);
     }
 
-    function testBurnBatchDecreasesSupply() public {
+    function testBurnBatchUnchangedSupply() public {
         testMintBatchSucceedsMinter();
         uint256 amount = 100;
 
@@ -202,10 +221,10 @@ contract UnitTestERC1155MaxSupplyMintable is BaseTest {
 
         assertEq(nft.balanceOf(address(this), tokenId), 0);
         assertEq(nft.balanceOf(address(this), tokenId + 1), 0);
-        assertEq(nft.totalSupply(tokenId), 0);
-        assertEq(nft.totalSupply(tokenId + 1), 0);
-        assertEq(nft.getMintAmountLeft(tokenId), supplyCap);
-        assertEq(nft.getMintAmountLeft(tokenId + 1), supplyCap);
+        assertEq(nft.totalSupply(tokenId), amount);
+        assertEq(nft.totalSupply(tokenId + 1), amount);
+        assertEq(nft.getMintAmountLeft(tokenId), supplyCap - amount);
+        assertEq(nft.getMintAmountLeft(tokenId + 1), supplyCap - amount);
     }
 
     function testSendTokensToContractFails() public {

--- a/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
+++ b/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
@@ -66,22 +66,64 @@ contract UnitTestERC1155MaxSupplyMintable is BaseTest {
         nft.setSupplyCap(tokenId, supplyCap - 1);
     }
 
-    function testSetSupplyCapAndTransferableWithoutRoleFails() public {
+    function testSetSupplyCapAndNonTransferableWithoutRoleFails() public {
         vm.expectRevert("CoreRef: no role on core");
-        nft.setSupplyCapAndTransferable(tokenId, supplyCap, true);
+        nft.setSupplyCapAndNonTransferable(tokenId, supplyCap, true);
     }
 
-    function testSetSupplyCapAndTransferableWithRoleSucceeds() public {
+    function testSetSupplyCapAndNonTransferableWithRoleSucceeds() public {
         uint256 newTokenId = tokenId + 1;
         uint256 newSupplyCap = 5000;
         bool isNonTransferable = true;
 
         vm.prank(addresses.adminAddress);
-        nft.setSupplyCapAndTransferable(newTokenId, newSupplyCap, isNonTransferable);
+        nft.setSupplyCapAndNonTransferable(newTokenId, newSupplyCap, isNonTransferable);
 
         assertEq(nft.maxTokenSupply(newTokenId), newSupplyCap);
         assertEq(nft.getMintAmountLeft(newTokenId), newSupplyCap);
         assertEq(nft.nonTransferableTokens(newTokenId), isNonTransferable);
+    }
+
+    function testSetSupplyCapAndNonTransferableWithZeroMaxSupplyFails() public {
+        uint256 newTokenId = tokenId + 1;
+
+        vm.expectRevert("BaseERC1155NFT: token must have a max supply greater than 0 to set the transferability");
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCapAndNonTransferable(newTokenId, 0, true);
+    }
+
+    function testSetNonTransferableWithoutRoleFails() public {
+        vm.expectRevert("CoreRef: no role on core");
+        nft.setNonTransferable(tokenId, true);
+    }
+
+    function testSetNonTransferableForUninitializedTokenFails() public {
+        uint256 uninitializedTokenId = tokenId + 100;
+
+        vm.expectRevert("BaseERC1155NFT: token must have a max supply greater than 0 to set the transferability");
+        vm.prank(addresses.adminAddress);
+        nft.setNonTransferable(uninitializedTokenId, true);
+    }
+
+    function testSetNonTransferableWithRoleSucceeds() public {
+        uint256 newTokenId = tokenId + 1;
+        uint256 newSupplyCap = 5000;
+
+        // First set the supply cap to initialize the token
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCap(newTokenId, newSupplyCap);
+
+        // Now set non-transferability
+        vm.prank(addresses.adminAddress);
+        nft.setNonTransferable(newTokenId, true);
+
+        assertEq(nft.nonTransferableTokens(newTokenId), true);
+
+        // Test setting it back to false
+        vm.prank(addresses.adminAddress);
+        nft.setNonTransferable(newTokenId, false);
+
+        assertEq(nft.nonTransferableTokens(newTokenId), false);
     }
 
     function testPauseWithoutRoleFails() public {

--- a/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
+++ b/test/unit/nfts/ERC1155MaxSupplyMintable.t.sol
@@ -126,6 +126,86 @@ contract UnitTestERC1155MaxSupplyMintable is BaseTest {
         assertEq(nft.nonTransferableTokens(newTokenId), false);
     }
 
+    function testTransferNonTransferableTokenFails() public {
+        uint256 newTokenId = tokenId + 1;
+        uint256 newSupplyCap = 5000;
+        uint256 mintAmount = 100;
+        address recipient = address(0x123);
+
+        // Set up a non-transferable token
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCapAndNonTransferable(newTokenId, newSupplyCap, true);
+
+        // Mint some tokens
+        vm.prank(address(sale));
+        lock.lock(1);
+
+        vm.prank(addresses.minterAddress);
+        nft.mint(address(this), newTokenId, mintAmount);
+
+        // Try to transfer and expect revert
+        vm.expectRevert("BaseERC1155NFT: token is non-transferable");
+        nft.safeTransferFrom(address(this), recipient, newTokenId, 1, "");
+    }
+
+    function testTransferableTokenCanBeTransferredUntilDisabled() public {
+        uint256 newTokenId = tokenId + 1;
+        uint256 newSupplyCap = 5000;
+        uint256 mintAmount = 100;
+        address recipient = address(0x123);
+
+        // Set up a transferable token (isNonTransferable = false)
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCapAndNonTransferable(newTokenId, newSupplyCap, false);
+
+        // Mint some tokens
+        vm.prank(address(sale));
+        lock.lock(1);
+
+        vm.prank(addresses.minterAddress);
+        nft.mint(address(this), newTokenId, mintAmount);
+
+        // Transfer should succeed
+        nft.safeTransferFrom(address(this), recipient, newTokenId, 1, "");
+        assertEq(nft.balanceOf(recipient, newTokenId), 1);
+        assertEq(nft.balanceOf(address(this), newTokenId), mintAmount - 1);
+
+        // Now disable transferability
+        vm.prank(addresses.adminAddress);
+        nft.setNonTransferable(newTokenId, true);
+
+        // Transfer should now fail
+        vm.expectRevert("BaseERC1155NFT: token is non-transferable");
+        nft.safeTransferFrom(address(this), recipient, newTokenId, 1, "");
+    }
+
+    function testNonTransferableTokenCanBeBurned() public {
+        uint256 newTokenId = tokenId + 1;
+        uint256 newSupplyCap = 5000;
+        uint256 mintAmount = 100;
+        uint256 burnAmount = 50;
+
+        // Set up a non-transferable token
+        vm.prank(addresses.adminAddress);
+        nft.setSupplyCapAndNonTransferable(newTokenId, newSupplyCap, true);
+
+        // Mint some tokens
+        vm.prank(address(sale));
+        lock.lock(1);
+
+        vm.prank(addresses.minterAddress);
+        nft.mint(address(this), newTokenId, mintAmount);
+
+        assertEq(nft.balanceOf(address(this), newTokenId), mintAmount);
+
+        // Burn should succeed even though token is non-transferable
+        nft.burn(address(this), newTokenId, burnAmount);
+
+        assertEq(nft.balanceOf(address(this), newTokenId), mintAmount - burnAmount);
+        // Total supply should remain unchanged (burns don't decrease total supply)
+        assertEq(nft.totalSupply(newTokenId), mintAmount);
+    }
+
     function testPauseWithoutRoleFails() public {
         vm.expectRevert("CoreRef: no role on core");
         nft.pause();


### PR DESCRIPTION
## Description

Enhanced ERC1155MaxSupplyMintable contract to support non-transferable tokens and improved total supply tracking to handle burned tokens correctly.

### Objectives
1. Enable creation of non-transferable (soulbound-like) tokens that can be minted and burned but not transferred between addresses
2. Fix total supply accounting to ensure burned tokens still count towards the max supply cap, preventing infinite minting through burn/mint cycles
3. Provide flexible admin controls to manage token transferability on a per-token basis

### Changes Made

**Contract Updates (`src/nfts/ERC1155MaxSupplyMintable.sol`):**
- Removed dependency on `ERC1155Supply` and implemented custom `totalSupply` tracking that only increments on mints (not decrements on burns)
- Added `nonTransferableTokens` mapping to track which token IDs are non-transferable
- Added `setSupplyCapAndNonTransferable()` and `setNonTransferable()` functions for admin control
- Enhanced `_beforeTokenTransfer()` hook to block transfers (but allow mints/burns) for non-transferable tokens

**Test Coverage (`test/unit/nfts/ERC1155MaxSupplyMintable.t.sol`):**
- Added 9 new comprehensive tests covering non-transferable token functionality

### Breaking Changes
None - This is backward compatible. Tokens are transferable by default unless explicitly marked as non-transferable.

---

### Author Checklist

_All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues._

I have...

-   [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [x] added `!` to the type prefix if API or client breaking change
-   [x] provided a link to the relevant issue or specification
-   [x] included the necessary unit and integration tests
-   [x] code is adequately commented
-   [ ] updated the relevant documentation or specification
-   [x] reviewed "Files changed" and left comments if necessary
-   [ ] confirmed all CI checks have passed

### Reviewers Checklist

_All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items._

I have...

-   [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-   [ ] confirmed `!` in the type prefix if API or client breaking change
-   [ ] confirmed all author checklist items have been addressed
-   [ ] reviewed service design and naming
-   [ ] reviewed documentation is accurate
-   [ ] reviewed tests and test coverage
-   [ ] manually tested (if applicable)
